### PR TITLE
fix: Only return the mime type and not the file type for header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+## Fixed
+- Only return `mime` in `getRawFile`
+
 ## `1.4.0`
 
 ### Changed

--- a/src/node/utils.js
+++ b/src/node/utils.js
@@ -236,7 +236,7 @@ const getRawFile = async ({ token, repo, path }) => {
       name: basename(path),
       path,
       type: "file",
-      mimeType,
+      mimeType: mimeType.mime,
       content: buffer.toString("base64")
     }
   };


### PR DESCRIPTION
The `FileType` package returns an object containing `{ ext: '.jpg', mime: 'image/jpg' }` when run on a buffer. We only need to pass on the mime entry, as only that is needed to build the HTTP response header.

Sending both resulted in a malformed HTTP Header and made serverless functions crash on netlify.

I didn't see this error locally, as the local runtime of `netlify-cli` seems to not be that strict about header checking.