### PR TITLE
Allow ordering by nested keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@designsystemsinternational/react-admin-github",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@designsystemsinternational/react-admin-github",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "dependencies": {
         "@octokit/core": "^3.6.0",
         "@octokit/endpoint": "^7.0.3",
@@ -15,6 +15,7 @@
         "file-type": "16.5.3",
         "js-base64": "^3.7.2",
         "jwt-simple": "^0.5.6",
+        "lodash.get": "^4.4.2",
         "mime-types": "^2.1.35",
         "node-fetch-commonjs": "^3.2.4",
         "slugify": "^1.6.5"
@@ -2238,6 +2239,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "peer": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4912,6 +4918,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "peer": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "file-type": "16.5.3",
     "js-base64": "^3.7.2",
     "jwt-simple": "^0.5.6",
+    "lodash.get": "^4.4.2",
     "mime-types": "^2.1.35",
     "node-fetch-commonjs": "^3.2.4",
     "slugify": "^1.6.5"

--- a/src/node/contents.js
+++ b/src/node/contents.js
@@ -12,6 +12,8 @@ const {
   uploadFile
 } = require("./utils");
 
+const getNestedObjectProperty = require("lodash.get");
+
 /**
   Reads, creates, updates and deletes files from the GitHub contents API.
   Handles both normal files and smart handling of JSON files based on handler setting
@@ -146,10 +148,14 @@ const getList = async (octokit, props) => {
 
   // Sort depending on the sort order
   const isAsc = sortOrder === "ASC";
+
   parsedData.sort((a, b) => {
-    if (a[sortField] < b[sortField]) {
+    const aField = getNestedObjectProperty(a, sortField);
+    const bField = getNestedObjectProperty(b, sortField);
+
+    if (aField < bField) {
       return isAsc ? -1 : 1;
-    } else if (a[sortField] > b[sortField]) {
+    } else if (aField > bField) {
       return isAsc ? 1 : -1;
     } else {
       return 0;


### PR DESCRIPTION
This uses `lodash.get` to lookup nested object keys used for sorting. This allows users to properly sort by `createdAt` in the UI (which is nested as `_ragInfo.createdAt`).