### PR TITLE
Remove Square Brackets from filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `1.5.3`
+
+### Fixed
+
+- Do remove square and curly brackets special characters from filename of uploaded files
+
 ## `1.5.2`
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@designsystemsinternational/react-admin-github",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/src/browser/utils.js
+++ b/src/browser/utils.js
@@ -267,11 +267,11 @@ const randomString = (length = 5) => {
 /**
   Turns a string into something that can be used in a filename
 **/
-const createFilename = (str, disableTimestamp, useRandomPrefix) => {
+export const createFilename = (str, disableTimestamp, useRandomPrefix) => {
   const slugified = slugify(str, {
     lower: true,
     trim: true,
-    remove: /[*+~()¿?'"¡!:@]/g
+    remove: /[*+~\[\]{}()¿?'"¡!:@]/g
   });
 
   const filename = disableTimestamp ? slugified : timestamp() + "-" + slugified;

--- a/test/browser/utils.test.js
+++ b/test/browser/utils.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveFilenameFromProperty } from "../../src/browser/utils";
+import {
+  resolveFilenameFromProperty,
+  createFilename
+} from "../../src/browser/utils";
 
 describe("browser.utils", () => {
   describe("resolveFilenameFromProperty", () => {
@@ -40,6 +43,20 @@ describe("browser.utils", () => {
           "fallback"
         )
       ).toBe("fallback");
+    });
+  });
+
+  describe("createFilename", () => {
+    it("should remove special characters", () => {
+      const result = createFilename("my~my+my-{amazing}@fi.le[26].jpg", true);
+      expect(result).toBe("mymymy-amazingfi.le26.jpg");
+    });
+
+    it('should add the timestamp if "disableTimestamp" is false', () => {
+      const result = createFilename("my-file.jpg");
+      expect(result).toMatch(
+        /^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-my-file.jpg$/
+      );
     });
   });
 });


### PR DESCRIPTION
With refracciones we recently had an issue of square brackets in a filename breaking the build process of the site.

While the error could be fixed in the build step, it still feels like a good idea to extend the list of special characters to be removed from a filename a bit more.

This PR
- adds square and curly brackets to the list of characters to be removed
- adds a simple test testing the expected behavior of filename creation